### PR TITLE
fix(web): align React versions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@ai-build-flow/ui": "file:../../packages/ui",
     "next": "^14.2.32",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "18.3.24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
       "dependencies": {
         "@ai-build-flow/ui": "file:../../packages/ui",
         "next": "^14.2.32",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@types/react": "18.3.24",
@@ -35,7 +35,7 @@
       }
     },
     "apps/web/node_modules/react": {
-      "version": "18.3.1",
+      "version": "18.2.0",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -45,14 +45,14 @@
       }
     },
     "apps/web/node_modules/react-dom": {
-      "version": "18.3.1",
+      "version": "18.2.0",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^18.2.0"
       }
     },
     "node_modules/@ai-build-flow/ui": {


### PR DESCRIPTION
## Summary
- align React and React DOM versions in web workspace with Next.js (18.2.0)
- update lockfile accordingly

## Testing
- `npm test`
- `npm run lint`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68bc5171cc908325a4bd39c151b14c74