### PR TITLE
fix: resolve package.json merge conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,10 @@
   ],
   "scripts": {
     "dev:web": "npm --workspace apps/web run dev",
-    "dev:mobile": "npm --workspace apps/mobile run start",
     "build:web": "npm --workspace apps/web run build",
     "start:web": "npm --workspace apps/web run start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx || true",
-    "format": "prettier -w .",
-    "test": "echo \"no tests\" && exit 0"
+    "format": "prettier -w ."
   },
   "devDependencies": {
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in package.json
- limit scripts to dev:web, build:web, start:web, lint, and format
- retain only eslint, eslint-config-next, prettier in devDependencies

## Testing
- `npm install` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68bc52766b5c8325b53c308b28f7c8c7