### PR TITLE
chore(ui): add Jest + RTL with sample test

### DIFF
--- a/packages/ui/jest.config.js
+++ b/packages/ui/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = { preset: 'ts-jest', testEnvironment: 'jsdom' };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,8 +4,17 @@
   "type": "module",
   "main": "src/index.ts",
   "exports": { ".": "./src/index.ts" },
+  "scripts": {
+    "test": "jest"
+  },
   "peerDependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "ts-jest": "^29.2.5",
+    "@testing-library/react": "^14.3.1"
   }
 }

--- a/packages/ui/src/Button.test.tsx
+++ b/packages/ui/src/Button.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Button } from './Button';
+
+test('renders default label', () => {
+  render(<Button />);
+  expect(screen.getByText('Click')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- add Jest and testing libraries to ui package
- configure Jest with ts-jest and jsdom
- add sample Button render test

## Testing
- `npm test --workspace packages/ui -- --dry-run` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ff922f0832586670003190fda5d