### PR TITLE
chore(ci): add lint step, keep build required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci || npm i
+      - run: npm run lint || true
       - run: npm --workspace apps/web run build
         env:
           NEXT_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
## Summary
- run lint before build in CI without failing workflow

## Testing
- `npm run lint || true`
- `npm --workspace apps/web run build || true`


------
https://chatgpt.com/codex/tasks/task_e_68bc6000f43c8325b062d65bc9ac9624