### PR TITLE
chore(web): add typescript dev deps for vercel

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,8 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@types/node": "24.3.1",
-    "@types/react": "19.1.12"
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.3.3",
+    "typescript": "^5.5.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,9 @@
         "next": "^14.2.5"
       },
       "devDependencies": {
-        "@types/node": "24.3.1",
-        "@types/react": "19.1.12"
+        "@types/node": "^20.11.30",
+        "@types/react": "^18.3.3",
+        "typescript": "^5.5.4"
       }
     },
     "apps/web/node_modules/@next/env": {


### PR DESCRIPTION
## Summary
- add TypeScript-related dev dependencies for apps/web to support Vercel builds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find module 'next/dist/compiled/babel/eslint-parser')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/loose-envify)*

------
https://chatgpt.com/codex/tasks/task_e_68bd48adafa88325953115ddf10e4889