### PR TITLE
chore(vercel): monorepo build without dashboard tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@
 3. **Local production build**
    - Run `npx vercel build --cwd apps/web` to verify the build locally.
 
+
+### Vercel deploy
+
+The root-level `vercel.json` installs dependencies at the repo root, then installs and builds the app in `apps/web`. With this config, Vercel can deploy from any branch without setting a custom Root Directory, though pointing a project directly at `apps/web` still works.

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export const dynamic = "force-dynamic";
+
+export default function Error({ error }: { error: Error }) {
+  return (
+    <main>
+      <h1>Something went wrong</h1>
+      <p>{error.message}</p>
+    </main>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <main>
+      <h1>Not Found</h1>
+    </main>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "next build",
-    "dev": "next dev",
-    "start": "next start"
+    "start": "next start",
+    "dev": "next dev"
   },
   "dependencies": {
     "next": "14.2.5"

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,7 @@
 {
-  "buildCommand": "npm run build",
-  "installCommand": "npm install",
-  "outputDirectory": ".next"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "npm ci --omit=optional",
+  "buildCommand": "npm ci --omit=optional && npm --prefix apps/web ci && npm --prefix apps/web run build",
+  "outputDirectory": "apps/web/.next"
 }


### PR DESCRIPTION
## Summary
- configure root `vercel.json` to install root deps then build `apps/web`
- ensure `apps/web` uses standard Next scripts and add App Router `error`/`not-found`/`layout`
- document simplified Vercel deployment flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to load parser './parser.js')*
- `npm run build:web`

------
https://chatgpt.com/codex/tasks/task_e_68bd543f20b88325b6344d8e67a30bc7