### PR TITLE
chore(ui): add testing libraries

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,5 +7,9 @@
   "peerDependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.0.0",
+    "@types/jest": "^29.5.11"
   }
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["jest"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary
- add testing-related dev dependencies for UI package
- configure TypeScript for UI tests with Jest types

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx tsc -p tsconfig.base.json --noEmit` *(fails: Cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_68bd6bdde4548325b6262d258e852780