### PR TITLE
feat(web): add simple studio preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ npm --workspace apps/web install
 npm --workspace apps/web run build
 npm --workspace apps/web start
 ```
+
+**Development:**
+```bash
+npm run dev:web
+```

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,30 +1,167 @@
-import Layout from "@/components/Layout";
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+type Project = {
+  slug: string;
+  name: string;
+  prompt: string;
+  createdAt: string;
+};
+
+function slugify(s: string) {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+    .slice(0, 60) || "project";
+}
 
 export default function Home() {
+  const [value, setValue] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+
+    setIsSending(true);
+
+    const name = trimmed;
+    const slugBase = slugify(name);
+    const slug = slugBase + "-" + Math.random().toString(36).slice(2, 7);
+
+    const project: Project = {
+      slug,
+      name,
+      prompt: trimmed,
+      createdAt: new Date().toISOString(),
+    };
+
+    const key = "ai_build_flow_projects";
+    const existing = JSON.parse(localStorage.getItem(key) || "[]") as Project[];
+    localStorage.setItem(key, JSON.stringify([project, ...existing]));
+
+    router.push(`/studio/${slug}`);
+  }
+
   return (
-    <Layout>
-      <section className="text-center py-20">
-        <h1 className="text-4xl md:text-5xl font-bold tracking-tight">
-          AI Build Flow — Web
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        background:
+          "radial-gradient(1000px 600px at 50% 30%, rgba(120,119,198,0.15), transparent 60%)",
+      }}
+    >
+      <div style={{ width: "min(900px, 92vw)" }}>
+        <h1
+          style={{
+            textAlign: "center",
+            fontSize: "clamp(28px, 5vw, 48px)",
+            fontWeight: 800,
+            marginBottom: 16,
+          }}
+        >
+          Build something <span style={{ color: "#f43f5e" }}>simple</span>
         </h1>
-        <p className="mt-4 text-lg text-gray-600">
-          Baseline build is working. Tailwind UI is now wired up.
+        <p style={{ textAlign: "center", opacity: 0.7, marginBottom: 28 }}>
+          Describe what you want. We’ll open a studio with a live preview.
         </p>
-        <div className="mt-8 flex items-center justify-center gap-3">
-          <a
-            href="/dashboard"
-            className="inline-flex items-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-gray-50"
+
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            background: "#111213",
+            border: "1px solid #232428",
+            borderRadius: 12,
+            padding: 12,
+            display: "flex",
+            gap: 8,
+          }}
+        >
+          <input
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="e.g. A simple investing dashboard with a watchlist and market cards"
+            style={{
+              flex: 1,
+              background: "transparent",
+              border: "none",
+              outline: "none",
+              color: "white",
+              fontSize: 16,
+              padding: "10px 12px",
+            }}
+          />
+          <button
+            type="submit"
+            disabled={isSending || !value.trim()}
+            style={{
+              background: "#7c3aed",
+              color: "white",
+              border: "none",
+              padding: "10px 14px",
+              borderRadius: 8,
+              fontWeight: 600,
+              opacity: isSending || !value.trim() ? 0.6 : 1,
+              cursor: isSending || !value.trim() ? "not-allowed" : "pointer",
+            }}
           >
-            Open Dashboard
-          </a>
-          <a
-            href="/docs"
-            className="inline-flex items-center rounded-md bg-black text-white px-4 py-2 text-sm font-medium hover:bg-gray-900"
-          >
-            Read Docs
-          </a>
-        </div>
-      </section>
-    </Layout>
+            {isSending ? "Opening…" : "Create"}
+          </button>
+        </form>
+
+        <RecentProjects />
+      </div>
+    </main>
   );
 }
+
+function RecentProjects() {
+  const router = useRouter();
+  const projects =
+    (typeof window !== "undefined" &&
+      JSON.parse(localStorage.getItem("ai_build_flow_projects") || "[]")) ||
+    [];
+
+  if (!projects.length) return null;
+
+  return (
+    <div style={{ marginTop: 28 }}>
+      <h3 style={{ marginBottom: 12, opacity: 0.8 }}>Recent projects</h3>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+          gap: 12,
+        }}
+      >
+        {projects.map((p: any) => (
+          <button
+            key={p.slug}
+            onClick={() => router.push(`/studio/${p.slug}`)}
+            style={{
+              textAlign: "left",
+              padding: 14,
+              borderRadius: 12,
+              background: "#0e0f10",
+              border: "1px solid #1f2024",
+              color: "white",
+              cursor: "pointer",
+            }}
+          >
+            <div style={{ fontWeight: 700, marginBottom: 4 }}>{p.name}</div>
+            <div style={{ opacity: 0.6, fontSize: 12 }}>
+              {new Date(p.createdAt).toLocaleString()}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/pages/studio/[slug].tsx
+++ b/apps/web/pages/studio/[slug].tsx
@@ -1,0 +1,265 @@
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useState } from "react";
+
+type Project = { slug: string; name: string; prompt: string; createdAt: string };
+
+function getProject(slug: string | string[] | undefined): Project | null {
+  if (!slug || typeof window === "undefined") return null;
+  const list: Project[] = JSON.parse(
+    localStorage.getItem("ai_build_flow_projects") || "[]"
+  );
+  return list.find((p) => p.slug === slug) || null;
+}
+
+function generateHtmlDoc(title: string, prompt: string) {
+  const safeTitle = title || "My App";
+  const description =
+    "Generated instant preview. Replace with real AI code-gen later.";
+
+  const main = `
+    <div class="shell">
+      <header class="topbar">
+        <strong>${safeTitle}</strong>
+        <span class="muted">preview</span>
+      </header>
+
+      <section class="content">
+        <div class="card">
+          <h2>Prompt</h2>
+          <p>${prompt.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</p>
+        </div>
+
+        <div class="grid">
+          <div class="card">
+            <h3>Widget A</h3>
+            <p>Shows a KPI or chart.</p>
+          </div>
+          <div class="card">
+            <h3>Widget B</h3>
+            <p>Another panel you asked for.</p>
+          </div>
+          <div class="card">
+            <h3>Widget C</h3>
+            <p>Extend with AI-generated components.</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  `;
+
+  const css = `
+    :root {
+      color-scheme: dark;
+      --bg: #0b0c0e;
+      --panel: #101114;
+      --border: #22242a;
+      --text: #e7e7ea;
+      --muted: #9aa0a6;
+      --accent: #7c3aed;
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; padding: 0; background: var(--bg); color: var(--text); font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial; }
+    .shell { min-height: 100%; display: grid; grid-template-rows: auto 1fr; }
+    .topbar { display: flex; justify-content: space-between; align-items: center; padding: 14px 16px; border-bottom: 1px solid var(--border); background: var(--panel); position: sticky; top: 0; }
+    .muted { color: var(--muted); font-size: 12px; }
+    .content { padding: 16px; max-width: 1100px; margin: 0 auto; }
+    .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 14px; }
+    h1, h2, h3 { margin: 0 0 8px; }
+    .grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); margin-top: 12px; }
+    a.button { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 8px; text-decoration: none; color: white; background: var(--accent); }
+  `;
+
+  return `
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <title>${safeTitle}</title>
+        <meta name="description" content="${description}"/>
+        <style>${css}</style>
+      </head>
+      <body>
+        ${main}
+      </body>
+    </html>
+  `;
+}
+
+export default function StudioPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+  const [project, setProject] = useState<Project | null>(null);
+  const [messages, setMessages] = useState<
+    { role: "user" | "assistant"; content: string }[]
+  >([]);
+
+  useEffect(() => {
+    if (!slug) return;
+    const p = getProject(slug);
+    setProject(p || null);
+    if (p) setMessages([{ role: "user", content: p.prompt }]);
+  }, [slug]);
+
+  const doc = useMemo(() => {
+    if (!project) return "<html><body>Missing project.</body></html>";
+    return generateHtmlDoc(project.name, project.prompt);
+  }, [project]);
+
+  if (!project) {
+    return (
+      <main style={{ padding: 24 }}>
+        <p style={{ opacity: 0.7 }}>Project not found.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        gridTemplateColumns: "minmax(260px, 380px) 1fr",
+      }}
+    >
+      <section
+        style={{
+          borderRight: "1px solid #1f2024",
+          background: "#0e0f10",
+          padding: 12,
+        }}
+      >
+        <header
+          style={{
+            padding: 10,
+            border: "1px solid #1f2024",
+            borderRadius: 10,
+            marginBottom: 10,
+          }}
+        >
+          <div style={{ fontWeight: 800 }}>{project.name}</div>
+          <div style={{ opacity: 0.6, fontSize: 12 }}>Studio</div>
+        </header>
+
+        <div
+          style={{
+            display: "grid",
+            gap: 8,
+            alignContent: "start",
+            height: "calc(100vh - 220px)",
+            overflowY: "auto",
+            paddingRight: 4,
+          }}
+        >
+          {messages.map((m, i) => (
+            <div
+              key={i}
+              style={{
+                background: m.role === "user" ? "#121316" : "#101114",
+                border: "1px solid #1f2024",
+                borderRadius: 10,
+                padding: 10,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 12,
+                  opacity: 0.65,
+                  marginBottom: 6,
+                  textTransform: "uppercase",
+                }}
+              >
+                {m.role}
+              </div>
+              {m.content}
+            </div>
+          ))}
+        </div>
+
+        <Composer
+          onSend={(text) =>
+            setMessages((prev) => [...prev, { role: "user", content: text }])
+          }
+        />
+      </section>
+
+      <section style={{ background: "#0b0c0e", padding: 12 }}>
+        <div
+          style={{
+            border: "1px solid #1f2024",
+            borderRadius: 12,
+            overflow: "hidden",
+            height: "calc(100vh - 24px)",
+            background: "black",
+          }}
+        >
+          <iframe
+            title="preview"
+            style={{ width: "100%", height: "100%", border: "none" }}
+            srcDoc={doc}
+          />
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function Composer({ onSend }: { onSend: (text: string) => void }) {
+  const [val, setVal] = useState("");
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const t = val.trim();
+    if (!t) return;
+    onSend(t);
+    setVal("");
+  }
+
+  return (
+    <form
+      onSubmit={submit}
+      style={{
+        position: "fixed",
+        bottom: 12,
+        left: 12,
+        width: "min(360px, calc(100vw - 24px))",
+        display: "flex",
+        gap: 8,
+        background: "#0f1013",
+        border: "1px solid #1f2024",
+        borderRadius: 12,
+        padding: 8,
+      }}
+    >
+      <input
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        placeholder="Say what to add next…"
+        style={{
+          flex: 1,
+          border: "none",
+          outline: "none",
+          background: "transparent",
+          color: "white",
+          padding: "10px 8px",
+        }}
+      />
+      <button
+        type="submit"
+        style={{
+          background: "#7c3aed",
+          color: "white",
+          border: "none",
+          padding: "10px 12px",
+          borderRadius: 8,
+          fontWeight: 700,
+          cursor: "pointer",
+        }}
+      >
+        Send
+      </button>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace web homepage with single-prompt form that stores projects in localStorage and navigates to a studio
- add `/studio/[slug]` route showing chat log and iframe preview generated from the prompt
- document development command in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef2a2801883258c14adba441fba0b