### PR TITLE
feat(studio): add client-side block engine and live preview

### DIFF
--- a/apps/web/pages/studio/[slug].tsx
+++ b/apps/web/pages/studio/[slug].tsx
@@ -1,52 +1,131 @@
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 
-type Project = { slug: string; name: string; prompt: string; createdAt: string };
+// Block model
+export type Block =
+  | { type: "hero"; title: string; subtitle?: string }
+  | { type: "stats"; items: { label: string; value: string }[] }
+  | { type: "table"; columns: string[]; rows?: string[][] };
 
-function getProject(slug: string | string[] | undefined): Project | null {
+type ProjectMeta = {
+  slug: string;
+  name: string;
+  prompt: string;
+  createdAt: string;
+};
+
+// ---- persistence helpers ----
+const projectKey = (slug: string) => `ai_build_flow_project_${slug}`;
+
+function loadProject(slug: string): { prompt: string; blocks: Block[] } | null {
+  if (typeof window === "undefined") return null;
+  const raw = localStorage.getItem(projectKey(slug));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function saveProject(
+  slug: string,
+  data: { prompt: string; blocks: Block[] }
+): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(projectKey(slug), JSON.stringify(data));
+}
+
+function initDefaultBlocks(prompt: string): Block[] {
+  return [{ type: "hero", title: prompt }];
+}
+
+function getProjectMeta(slug: string | string[] | undefined): ProjectMeta | null {
   if (!slug || typeof window === "undefined") return null;
-  const list: Project[] = JSON.parse(
+  const list: ProjectMeta[] = JSON.parse(
     localStorage.getItem("ai_build_flow_projects") || "[]"
   );
   return list.find((p) => p.slug === slug) || null;
 }
 
-function generateHtmlDoc(title: string, prompt: string) {
-  const safeTitle = title || "My App";
-  const description =
-    "Generated instant preview. Replace with real AI code-gen later.";
+// ---- command parser ----
+export function parseCommand(
+  input: string
+): {
+  type: "ok" | "error";
+  apply?: (prev: Block[]) => Block[];
+  message: string;
+} {
+  const text = input.trim();
+  let m: RegExpMatchArray | null;
 
-  const main = `
-    <div class="shell">
-      <header class="topbar">
-        <strong>${safeTitle}</strong>
-        <span class="muted">preview</span>
-      </header>
+  if ((m = text.match(/^add\s+hero\s+(.+)$/i))) {
+    const title = m[1].trim();
+    return {
+      type: "ok",
+      message: "Added hero",
+      apply: (prev) => [...prev, { type: "hero", title }],
+    };
+  }
 
-      <section class="content">
-        <div class="card">
-          <h2>Prompt</h2>
-          <p>${prompt.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</p>
-        </div>
+  if ((m = text.match(/^add\s+stats\s+(.+)$/i))) {
+    const items = m[1]
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((seg) => {
+        const [label, value] = seg.split(":").map((s) => s.trim());
+        return { label: label || "", value: value || "" };
+      });
+    return {
+      type: "ok",
+      message: "Added stats",
+      apply: (prev) => [...prev, { type: "stats", items }],
+    };
+  }
 
-        <div class="grid">
-          <div class="card">
-            <h3>Widget A</h3>
-            <p>Shows a KPI or chart.</p>
-          </div>
-          <div class="card">
-            <h3>Widget B</h3>
-            <p>Another panel you asked for.</p>
-          </div>
-          <div class="card">
-            <h3>Widget C</h3>
-            <p>Extend with AI-generated components.</p>
-          </div>
-        </div>
-      </section>
-    </div>
-  `;
+  if ((m = text.match(/^add\s+table\s+columns:\s*(.+)$/i))) {
+    const columns = m[1]
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return {
+      type: "ok",
+      message: "Added table",
+      apply: (prev) => [...prev, { type: "table", columns }],
+    };
+  }
 
+  if ((m = text.match(/^remove\s+(\d+)$/i))) {
+    const idx = parseInt(m[1], 10) - 1;
+    return {
+      type: "ok",
+      message: `Removed ${m[1]}`,
+      apply: (prev) => {
+        if (idx < 0 || idx >= prev.length) return prev;
+        const next = [...prev];
+        next.splice(idx, 1);
+        return next;
+      },
+    };
+  }
+
+  if (/^clear$/i.test(text)) {
+    return { type: "ok", message: "Cleared", apply: () => [] };
+  }
+
+  return {
+    type: "error",
+    message: "Sorry, I didn’t understand. Try: add hero Hello",
+  };
+}
+
+// ---- renderer ----
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function renderBlocksToHtml(blocks: Block[]): string {
   const css = `
     :root {
       color-scheme: dark;
@@ -55,58 +134,131 @@ function generateHtmlDoc(title: string, prompt: string) {
       --border: #22242a;
       --text: #e7e7ea;
       --muted: #9aa0a6;
-      --accent: #7c3aed;
     }
     * { box-sizing: border-box; }
-    html, body { height: 100%; margin: 0; padding: 0; background: var(--bg); color: var(--text); font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial; }
-    .shell { min-height: 100%; display: grid; grid-template-rows: auto 1fr; }
-    .topbar { display: flex; justify-content: space-between; align-items: center; padding: 14px 16px; border-bottom: 1px solid var(--border); background: var(--panel); position: sticky; top: 0; }
-    .muted { color: var(--muted); font-size: 12px; }
-    .content { padding: 16px; max-width: 1100px; margin: 0 auto; }
-    .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 14px; }
-    h1, h2, h3 { margin: 0 0 8px; }
-    .grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); margin-top: 12px; }
-    a.button { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 8px; text-decoration: none; color: white; background: var(--accent); }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 16px/1.5 system-ui, sans-serif;
+      padding: 20px;
+    }
+    h1, h2, h3, p { margin: 0 0 12px; }
+    .hero { text-align: center; padding: 60px 20px; }
+    .hero h1 { font-size: 2.5rem; margin-bottom: 12px; }
+    .hero p { color: var(--muted); }
+    .stats { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); margin: 20px 0; }
+    .stat { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 12px; }
+    .stat .label { font-size: 12px; color: var(--muted); }
+    .stat .value { font-size: 20px; font-weight: 700; }
+    table { width: 100%; border-collapse: collapse; margin: 20px 0; }
+    th, td { border: 1px solid var(--border); padding: 8px; text-align: left; }
+    th { background: var(--panel); }
+    .empty { text-align: center; opacity: 0.7; padding: 40px; }
   `;
 
-  return `
-    <!doctype html>
-    <html lang="en">
-      <head>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
-        <title>${safeTitle}</title>
-        <meta name="description" content="${description}"/>
-        <style>${css}</style>
-      </head>
-      <body>
-        ${main}
-      </body>
-    </html>
-  `;
+  const body =
+    blocks.length === 0
+      ? '<div class="empty">No blocks yet. Try add hero Welcome in the chat.</div>'
+      : blocks
+          .map((b) => {
+            if (b.type === "hero") {
+              return `<section class="hero"><h1>${escapeHtml(
+                b.title
+              )}</h1>${b.subtitle ? `<p>${escapeHtml(b.subtitle)}</p>` : ""}</section>`;
+            }
+            if (b.type === "stats") {
+              return `<section class="stats">${b.items
+                .map(
+                  (it) =>
+                    `<div class="stat"><div class="label">${escapeHtml(
+                      it.label
+                    )}</div><div class="value">${escapeHtml(it.value)}</div></div>`
+                )
+                .join("")}</section>`;
+            }
+            if (b.type === "table") {
+              const header = b.columns
+                .map((c) => `<th>${escapeHtml(c)}</th>`)
+                .join("");
+              const rows = (b.rows || [])
+                .map(
+                  (r) =>
+                    `<tr>${r
+                      .map((c) => `<td>${escapeHtml(c)}</td>`)
+                      .join("")}</tr>`
+                )
+                .join("");
+              return `<section class="table"><table><thead><tr>${header}</tr></thead><tbody>${rows}</tbody></table></section>`;
+            }
+            return "";
+          })
+          .join("");
+
+  return `<!doctype html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><style>${css}</style></head><body>${body}</body></html>`;
 }
 
+// ---- UI ----
 export default function StudioPage() {
   const router = useRouter();
   const { slug } = router.query;
-  const [project, setProject] = useState<Project | null>(null);
-  const [messages, setMessages] = useState<
-    { role: "user" | "assistant"; content: string }[]
-  >([]);
 
+  const [meta, setMeta] = useState<ProjectMeta | null>(null);
+  const [prompt, setPrompt] = useState<string>("");
+  const [blocks, setBlocks] = useState<Block[]>([]);
+  const [feedback, setFeedback] = useState<string>("");
+  const [isBusy, setIsBusy] = useState(false);
+
+  // initial load
   useEffect(() => {
-    if (!slug) return;
-    const p = getProject(slug);
-    setProject(p || null);
-    if (p) setMessages([{ role: "user", content: p.prompt }]);
-  }, [slug]);
+    if (!slug || typeof slug !== "string") return;
+    const metaProj = getProjectMeta(slug);
+    setMeta(metaProj);
 
-  const doc = useMemo(() => {
-    if (!project) return "<html><body>Missing project.</body></html>";
-    return generateHtmlDoc(project.name, project.prompt);
-  }, [project]);
+    const stored = loadProject(slug);
+    if (stored) {
+      setPrompt(stored.prompt || "My first project");
+      setBlocks(stored.blocks || []);
+      return;
+    }
 
-  if (!project) {
+    const initialPrompt =
+      (router.query.prompt as string) || metaProj?.prompt || "My first project";
+    setPrompt(initialPrompt);
+    const initBlocks = initDefaultBlocks(initialPrompt);
+    setBlocks(initBlocks);
+    saveProject(slug, { prompt: initialPrompt, blocks: initBlocks });
+  }, [slug, router.query.prompt]);
+
+  // persist on change
+  useEffect(() => {
+    if (!slug || typeof slug !== "string") return;
+    if (!prompt) return;
+    saveProject(slug, { prompt, blocks });
+  }, [slug, prompt, blocks]);
+
+  const doc = useMemo(() => renderBlocksToHtml(blocks), [blocks]);
+
+  function handleCommand(text: string) {
+    if (isBusy) return;
+    setIsBusy(true);
+    const result = parseCommand(text);
+    if (result.type === "ok" && result.apply) {
+      setBlocks((prev) => result.apply!(prev));
+    }
+    setFeedback(result.message);
+    setTimeout(() => setFeedback(""), 2000);
+    setIsBusy(false);
+  }
+
+  function summary(b: Block): string {
+    if (b.type === "hero") return `hero — ${b.title}`;
+    if (b.type === "stats") return `stats — ${b.items.length} items`;
+    if (b.type === "table") return `table — ${b.columns.length} cols`;
+    return b.type;
+  }
+
+  if (!slug || (meta === null && !prompt)) {
     return (
       <main style={{ padding: 24 }}>
         <p style={{ opacity: 0.7 }}>Project not found.</p>
@@ -127,6 +279,8 @@ export default function StudioPage() {
           borderRight: "1px solid #1f2024",
           background: "#0e0f10",
           padding: 12,
+          display: "flex",
+          flexDirection: "column",
         }}
       >
         <header
@@ -135,52 +289,92 @@ export default function StudioPage() {
             border: "1px solid #1f2024",
             borderRadius: 10,
             marginBottom: 10,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
           }}
         >
-          <div style={{ fontWeight: 800 }}>{project.name}</div>
-          <div style={{ opacity: 0.6, fontSize: 12 }}>Studio</div>
+          <div>
+            <div style={{ fontWeight: 800 }}>{meta?.name || "Project"}</div>
+            <div style={{ opacity: 0.6, fontSize: 12 }}>Studio</div>
+          </div>
+          <button
+            onClick={() => setBlocks(initDefaultBlocks(prompt))}
+            style={{
+              background: "transparent",
+              border: "none",
+              color: "#f87171",
+              cursor: "pointer",
+              fontSize: 12,
+            }}
+          >
+            Reset
+          </button>
         </header>
 
-        <div
+        <ul
           style={{
-            display: "grid",
-            gap: 8,
-            alignContent: "start",
-            height: "calc(100vh - 220px)",
+            flex: 1,
             overflowY: "auto",
-            paddingRight: 4,
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+            display: "grid",
+            gap: 6,
           }}
         >
-          {messages.map((m, i) => (
-            <div
+          {blocks.map((b, i) => (
+            <li
               key={i}
               style={{
-                background: m.role === "user" ? "#121316" : "#101114",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                background: "#121316",
                 border: "1px solid #1f2024",
-                borderRadius: 10,
-                padding: 10,
-                whiteSpace: "pre-wrap",
+                borderRadius: 8,
+                padding: "8px 10px",
+                fontSize: 14,
               }}
             >
-              <div
+              <span
                 style={{
-                  fontSize: 12,
-                  opacity: 0.65,
-                  marginBottom: 6,
-                  textTransform: "uppercase",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
                 }}
               >
-                {m.role}
-              </div>
-              {m.content}
-            </div>
+                {i + 1}. {summary(b)}
+              </span>
+              <button
+                onClick={() =>
+                  setBlocks((prev) => prev.filter((_, idx) => idx !== i))
+                }
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: "#9aa0a6",
+                  cursor: "pointer",
+                  marginLeft: 8,
+                }}
+                aria-label={`remove ${i + 1}`}
+              >
+                ×
+              </button>
+            </li>
           ))}
-        </div>
+        </ul>
+
+        {feedback && (
+          <div style={{ fontSize: 12, opacity: 0.7, marginTop: 8 }}>
+            {feedback}
+          </div>
+        )}
 
         <Composer
-          onSend={(text) =>
-            setMessages((prev) => [...prev, { role: "user", content: text }])
-          }
+          onSend={handleCommand}
+          disabled={isBusy}
+          placeholder='Tell me what to add (e.g. "add stats Revenue: $1.2M; Users: 42k")'
         />
       </section>
 
@@ -205,13 +399,21 @@ export default function StudioPage() {
   );
 }
 
-function Composer({ onSend }: { onSend: (text: string) => void }) {
+function Composer({
+  onSend,
+  disabled,
+  placeholder,
+}: {
+  onSend: (text: string) => void;
+  disabled?: boolean;
+  placeholder: string;
+}) {
   const [val, setVal] = useState("");
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
     const t = val.trim();
-    if (!t) return;
+    if (!t || disabled) return;
     onSend(t);
     setVal("");
   }
@@ -219,46 +421,39 @@ function Composer({ onSend }: { onSend: (text: string) => void }) {
   return (
     <form
       onSubmit={submit}
-      style={{
-        position: "fixed",
-        bottom: 12,
-        left: 12,
-        width: "min(360px, calc(100vw - 24px))",
-        display: "flex",
-        gap: 8,
-        background: "#0f1013",
-        border: "1px solid #1f2024",
-        borderRadius: 12,
-        padding: 8,
-      }}
+      style={{ display: "flex", gap: 8, marginTop: 8 }}
     >
       <input
         value={val}
         onChange={(e) => setVal(e.target.value)}
-        placeholder="Say what to add next…"
+        disabled={disabled}
+        placeholder={placeholder}
         style={{
           flex: 1,
-          border: "none",
-          outline: "none",
-          background: "transparent",
+          border: "1px solid #1f2024",
+          background: "#0f1013",
           color: "white",
-          padding: "10px 8px",
+          borderRadius: 8,
+          padding: "10px 12px",
+          outline: "none",
         }}
       />
       <button
-        type="submit"
-        style={{
-          background: "#7c3aed",
-          color: "white",
-          border: "none",
-          padding: "10px 12px",
-          borderRadius: 8,
-          fontWeight: 700,
-          cursor: "pointer",
-        }}
-      >
-        Send
-      </button>
+          type="submit"
+          disabled={disabled || !val.trim()}
+          style={{
+            background: "#7c3aed",
+            color: "white",
+            border: "none",
+            padding: "10px 12px",
+            borderRadius: 8,
+            fontWeight: 700,
+            cursor: disabled || !val.trim() ? "not-allowed" : "pointer",
+            opacity: disabled || !val.trim() ? 0.6 : 1,
+          }}
+        >
+          Send
+        </button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- implement client-side Block model with localStorage persistence
- add command parser and block list UI for Studio page
- render blocks to HTML with live iframe preview

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfca34d59083258d86ff3679437900