### PR TITLE
feat(web): add reusable '+' menu and base ui components

### DIFF
--- a/apps/web/components/ui/AddMenu.tsx
+++ b/apps/web/components/ui/AddMenu.tsx
@@ -1,0 +1,36 @@
+"use client";
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Command, CommandGroup, CommandItem, CommandList } from "@/components/ui/command";
+import { Separator } from "@/components/ui/separator";
+
+type MenuAction = "text" | "todo" | "help" | "prd";
+
+export function AddMenu({ onSelect }: { onSelect: (action: MenuAction) => void }) {
+  const [open, setOpen] = React.useState(false);
+  const choose = (a: MenuAction) => { onSelect(a); setOpen(false); };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button size="sm" variant="secondary" aria-label="Add">+</Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-60 p-0" align="start">
+        <Command>
+          <CommandList>
+            <CommandGroup heading="Add Content">
+              <CommandItem onSelect={() => choose("text")}>Text</CommandItem>
+              <CommandItem onSelect={() => choose("todo")}>To-Do</CommandItem>
+            </CommandGroup>
+            <Separator className="my-1" />
+            <CommandGroup>
+              <CommandItem onSelect={() => choose("help")}>Get Help</CommandItem>
+              <CommandItem onSelect={() => choose("prd")}>Generate PRD</CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Variant = "default" | "secondary";
+type Size = "default" | "sm";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+}
+
+const variantClasses: Record<Variant, string> = {
+  default: "bg-primary text-primary-foreground hover:bg-primary/90",
+  secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+};
+
+const sizeClasses: Record<Size, string> = {
+  default: "h-10 px-4 py-2",
+  sm: "h-9 px-3",
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "default", ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background",
+          variantClasses[variant],
+          sizeClasses[size],
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)} {...props} />;
+}
+
+export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />;
+}
+
+export function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-6 pt-0", className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex items-center p-6 pt-0", className)} {...props} />;
+}

--- a/apps/web/components/ui/command.tsx
+++ b/apps/web/components/ui/command.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function Command({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex h-full w-full flex-col overflow-hidden", className)} {...props} />;
+}
+
+export function CommandList({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("max-h-60 overflow-y-auto", className)} {...props} />;
+}
+
+export function CommandGroup({ heading, className, ...props }: React.HTMLAttributes<HTMLDivElement> & { heading?: React.ReactNode; }) {
+  return (
+    <div className={cn("p-1", className)} {...props}>
+      {heading && (
+        <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+          {heading}
+        </div>
+      )}
+      {props.children}
+    </div>
+  );
+}
+
+export function CommandItem({ className, onSelect, ...props }: React.HTMLAttributes<HTMLDivElement> & { onSelect?: () => void }) {
+  return (
+    <div
+      className={cn(
+        "cursor-pointer select-none rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground",
+        className
+      )}
+      onClick={onSelect}
+      {...props}
+    />
+  );
+}

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface DialogContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+const DialogContext = React.createContext<DialogContextValue | undefined>(undefined);
+
+export interface DialogProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export function Dialog({ open, onOpenChange, children }: DialogProps) {
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const isControlled = open !== undefined;
+  const actualOpen = isControlled ? open! : internalOpen;
+  const setOpen = (o: boolean) => {
+    if (!isControlled) setInternalOpen(o);
+    onOpenChange?.(o);
+  };
+  return (
+    <DialogContext.Provider value={{ open: actualOpen, setOpen }}>
+      {children}
+    </DialogContext.Provider>
+  );
+}
+
+export function DialogTrigger({ children }: { children: React.ReactElement }) {
+  const ctx = React.useContext(DialogContext);
+  if (!ctx) throw new Error("Dialog components must be used inside <Dialog>");
+  const child = React.Children.only(children);
+  return React.cloneElement(child, {
+    onClick: (e: any) => {
+      child.props.onClick?.(e);
+      ctx.setOpen(true);
+    },
+  });
+}
+
+export function DialogContent({ className, children }: React.HTMLAttributes<HTMLDivElement>) {
+  const ctx = React.useContext(DialogContext);
+  if (!ctx || !ctx.open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={() => ctx.setOpen(false)} />
+      <div className={cn("z-50 w-full max-w-lg rounded-lg bg-background p-6 shadow-lg", className)}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />;
+}
+
+export function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />;
+}
+
+export function DialogTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />;
+}
+
+export function DialogDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface MenuContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+const MenuContext = React.createContext<MenuContextValue | undefined>(undefined);
+
+export function DropdownMenu({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  return <MenuContext.Provider value={{ open, setOpen }}>{children}</MenuContext.Provider>;
+}
+
+export function DropdownMenuTrigger({ children }: { children: React.ReactElement }) {
+  const ctx = React.useContext(MenuContext);
+  if (!ctx) throw new Error("DropdownMenu components must be used inside <DropdownMenu>");
+  const child = React.Children.only(children);
+  return React.cloneElement(child, {
+    onClick: (e: any) => {
+      child.props.onClick?.(e);
+      ctx.setOpen(!ctx.open);
+    },
+  });
+}
+
+export function DropdownMenuContent({ className, children }: React.HTMLAttributes<HTMLDivElement>) {
+  const ctx = React.useContext(MenuContext);
+  if (!ctx || !ctx.open) return null;
+  return (
+    <div className={cn("z-50 mt-2 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md", className)}>
+      {children}
+    </div>
+  );
+}
+
+export function DropdownMenuItem({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "cursor-pointer select-none rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface PopoverContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+const PopoverContext = React.createContext<PopoverContextValue | undefined>(undefined);
+
+export interface PopoverProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export function Popover({ open, onOpenChange, children }: PopoverProps) {
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const isControlled = open !== undefined;
+  const actualOpen = isControlled ? open! : internalOpen;
+  const setOpen = (o: boolean) => {
+    if (!isControlled) setInternalOpen(o);
+    onOpenChange?.(o);
+  };
+  return (
+    <PopoverContext.Provider value={{ open: actualOpen, setOpen }}>
+      {children}
+    </PopoverContext.Provider>
+  );
+}
+
+export function PopoverTrigger({ asChild, children }: { asChild?: boolean; children: React.ReactElement; }) {
+  const ctx = React.useContext(PopoverContext);
+  if (!ctx) throw new Error("Popover components must be used inside <Popover>");
+  const child = React.Children.only(children);
+  return React.cloneElement(child, {
+    onClick: (e: any) => {
+      child.props.onClick?.(e);
+      ctx.setOpen(!ctx.open);
+    },
+  });
+}
+
+export function PopoverContent({ className, children }: React.HTMLAttributes<HTMLDivElement>) {
+  const ctx = React.useContext(PopoverContext);
+  if (!ctx || !ctx.open) return null;
+  return (
+    <div className={cn("z-50 mt-2 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none", className)}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/ui/separator.tsx
+++ b/apps/web/components/ui/separator.tsx
@@ -1,0 +1,6 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function Separator({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("shrink-0 bg-border h-px w-full", className)} {...props} />;
+}

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface TooltipContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+const TooltipContext = React.createContext<TooltipContextValue | undefined>(undefined);
+
+export function Tooltip({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  return <TooltipContext.Provider value={{ open, setOpen }}>{children}</TooltipContext.Provider>;
+}
+
+export function TooltipTrigger({ children }: { children: React.ReactElement }) {
+  const ctx = React.useContext(TooltipContext);
+  if (!ctx) throw new Error("Tooltip components must be used inside <Tooltip>");
+  const child = React.Children.only(children);
+  return React.cloneElement(child, {
+    onMouseEnter: (e: any) => {
+      child.props.onMouseEnter?.(e);
+      ctx.setOpen(true);
+    },
+    onMouseLeave: (e: any) => {
+      child.props.onMouseLeave?.(e);
+      ctx.setOpen(false);
+    },
+  });
+}
+
+export function TooltipContent({ className, children }: React.HTMLAttributes<HTMLDivElement>) {
+  const ctx = React.useContext(TooltipContext);
+  if (!ctx || !ctx.open) return null;
+  return (
+    <div className={cn("z-50 rounded-md border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md", className)}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -1,3 +1,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Smoothing + subtle defaults */
+html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }


### PR DESCRIPTION
## Summary
- add AddMenu popover for PRD actions
- introduce minimal shadcn-style ui components
- smooth fonts in global styles

## Testing
- `npm run lint`
- `npx shadcn-ui@latest init --help` *(fails: 403 Forbidden)*
- `npx shadcn-ui@latest add button popover dropdown-menu command card separator tooltip dialog` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c12b04e49c8325b2800e4b2374802f