### PR TITLE
chore: regenerate lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,12 @@
         "typescript": "^5.9.2"
       },
       "devDependencies": {
+        "autoprefixer": "^10.4.21",
         "eslint": "^8.57.0",
         "eslint-config-next": "14.2.5",
-        "prettier": "^3.3.3",
-        "tailwindcss": "^3.4.17",
         "postcss": "^8.4.31",
-        "autoprefixer": "^10.4.21"
+        "prettier": "^3.3.3",
+        "tailwindcss": "^3.4.17"
       }
     },
     "apps/web": {
@@ -790,12 +790,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -803,7 +803,8 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "19.1.12",
@@ -6357,9 +6358,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {


### PR DESCRIPTION
## Summary
- remove the old npm lockfile and regenerate it using npm install
- update dependency metadata such as @types/node and undici-types in the new lockfile

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68d5357689848325ac81ccfd633b0e1b