### PR TITLE
Add marked and uuid dependencies to web app

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,8 +9,10 @@
     "start": "next start"
   },
   "dependencies": {
+    "marked": "12.0.2",
     "next": "^14.2.32",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "uuid": "9.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- add the marked and uuid packages to the web workspace dependencies
- npm install still fails in this environment due to a 403 when downloading @types/marked

## Testing
- npm --workspace apps/web run build

------
https://chatgpt.com/codex/tasks/task_e_68d5393cd71c832582de833ee2897eb9