### PR TITLE
Align studio flow with PRD: consolidate routes, document plan, and apply small safe fixes

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -132,10 +132,6 @@ function RecentProjects() {
                 Last opened {new Date(p.createdAt).toLocaleTimeString()}
               </span>
             </div>
-            <p className="mt-2 line-clamp-2 text-sm text-muted-foreground">{p.prompt}</p>
-            <span className="mt-4 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
-              Last opened {new Date(p.createdAt).toLocaleTimeString()}
-            </span>
           </button>
         ))}
       </div>

--- a/apps/web/pages/studio/[slug].tsx
+++ b/apps/web/pages/studio/[slug].tsx
@@ -276,6 +276,7 @@ export default function StudioPage() {
         return 'block';
       }
     }
+  };
 
   if (!slug || (meta === null && !prompt)) {
     return (

--- a/apps/web/pages/studio/index.tsx
+++ b/apps/web/pages/studio/index.tsx
@@ -1,54 +1,12 @@
-import dynamic from "next/dynamic";
-import Head from "next/head";
-import { usePRD, serialize, deserialize } from "@/store/prdStore";
-import { toSingleMarkdownDoc, download } from "@/lib/prdMarkdown";
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
-const PRDCanvas = dynamic(() => import("@/components/prd/PRDCanvas"), { ssr: false });
-const PRDEditor = dynamic(() => import("@/components/prd/PRDEditor"), { ssr: false });
+export default function StudioIndexRedirect() {
+  const router = useRouter();
 
-export default function StudioPage() {
-  const { blocks, edges, addBlock, reset } = usePRD();
+  useEffect(() => {
+    router.replace('/');
+  }, [router]);
 
-  const exportJSON = () => {
-    const text = serialize({ blocks, edges, version: 1 });
-    download("prd-graph.json", text, "application/json;charset=utf-8");
-  };
-
-  const importJSON = (file: File) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      try { reset(deserialize(String(reader.result))); } catch {}
-    };
-    reader.readAsText(file);
-  };
-
-  const exportPRD = () => {
-    const md = toSingleMarkdownDoc({ blocks, edges, version: 1 });
-    download("PRD.md", md);
-  };
-
-  return (
-    <>
-      <Head><title>PRD Studio</title></Head>
-      <div className="grid h-[calc(100vh-32px)] grid-cols-[2fr_1fr] gap-4 p-4">
-        <div className="flex flex-col gap-2">
-          <div className="flex gap-2">
-            <button onClick={() => addBlock()} className="border rounded px-3 py-1">+ Add Node</button>
-            <button onClick={exportJSON} className="border rounded px-3 py-1">Export JSON</button>
-            <label className="border rounded px-3 py-1 cursor-pointer">
-              Import JSON
-              <input type="file" accept="application/json" onChange={e => e.target.files && importJSON(e.target.files[0])} hidden />
-            </label>
-            <button onClick={exportPRD} className="border rounded px-3 py-1">Export PRD.md</button>
-          </div>
-          <div className="flex-1 min-h-0">
-            <PRDCanvas />
-          </div>
-        </div>
-        <div className="h-full">
-          <PRDEditor />
-        </div>
-      </div>
-    </>
-  );
+  return null;
 }

--- a/docs/studio-alignment-review.md
+++ b/docs/studio-alignment-review.md
@@ -1,0 +1,97 @@
+# Review: Align product with PRD — unify studio and AI generation flow
+
+_Date: 2026-03-23_
+
+## Scope and note
+
+The request referenced `/ai/PRD.md`, but that file does not exist in this repository. I used `docs/ai-build-flow-prd.md` as the source PRD for this review.
+
+## PRD direction recap
+
+From the PRD, the intended MVP flow is:
+
+1. User enters a natural-language prompt on landing.
+2. System generates structured blocks (hero/stats/table/etc).
+3. User edits those blocks in a single studio.
+4. Live preview updates from the same data model.
+
+The PRD also explicitly requires:
+
+- one unified studio
+- Zustand as single source of truth
+- command input as a layer that modifies the same store
+- React Flow as optional advanced mode (not separate product)
+
+## Current divergence in `apps/web`
+
+### 1) Duplicate studio implementations
+
+There are two separate studio experiences:
+
+- `pages/studio/[slug].tsx`: block-list + command composer + iframe preview using `localStorage`-based project state.
+- `pages/studio/index.tsx`: PRD graph studio using Zustand store + React Flow + markdown editor.
+
+These are separate architectures and data models, violating the single unified studio direction.
+
+### 2) Landing flow bypasses Zustand and AI generation layer
+
+Landing (`pages/index.tsx`) creates a project in `localStorage` and routes to `/studio/[slug]`.
+
+That route creates only a default hero block from prompt and then relies on manual command parsing. There is no dedicated AI generation stage that translates prompt to structured blocks before first render.
+
+### 3) Inconsistent block schemas
+
+- `[slug].tsx` uses a local `Block` union (`hero|stats|table`) with index-based removal.
+- Zustand store (`store/prdStore.ts`) uses `PRDBlock` graph nodes (`feature|page|flow|api|task`) with positional metadata and edges.
+
+These can’t be shared without adapters, causing product drift.
+
+### 4) Route-level product ambiguity
+
+`/studio` currently opens a different product than `/studio/[slug]`. This increases user confusion and makes acceptance criteria “studio loads same project consistently” hard to satisfy.
+
+## Minimal refactor plan (no large rewrites yet)
+
+### Phase 0 — Stability and direction lock (small safe)
+
+1. Keep `/studio/[slug]` as the canonical MVP studio route for now.
+2. Convert `/studio` into a redirect back to landing (`/`) to remove the duplicate entry point while refactor is in progress.
+3. Fix obvious studio rendering quality issues (done in this PR: duplicate text in recent project cards).
+
+### Phase 1 — Unify data model behind a shared store
+
+1. Introduce a single `StudioProject` Zustand store shape for prompt + block list + metadata.
+2. Add serialization helpers in one place (load/save by slug).
+3. Move `[slug].tsx` to consume only the shared store (no local component state as source of truth).
+
+### Phase 2 — Add AI generation seam (without full model integration)
+
+1. Add `generateBlocksFromPrompt(prompt)` interface in a dedicated module (e.g., `lib/ai/generateBlocks.ts`).
+2. Start with deterministic local fallback mapping (template-based) to satisfy MVP behavior and keep builds stable.
+3. Wire landing submit to call this generator before opening studio; persist generated blocks into shared store.
+
+### Phase 3 — Optional advanced mode, not separate app
+
+1. Reuse shared store in React Flow canvas.
+2. Expose graph view via a toggle/tab inside the same studio route.
+3. Keep command input/editor and graph editing as alternate views over identical data.
+
+### Phase 4 — Cleanup and acceptance checks
+
+1. Remove dead/legacy dual-studio code paths.
+2. Add tests for:
+   - prompt -> generated blocks
+   - store persistence by slug
+   - preview reflects block edits
+3. Run build/lint to ensure Vercel compatibility.
+
+## Small safe fixes included now
+
+1. `/studio` now redirects to landing instead of rendering a second, divergent studio implementation.
+2. Landing recent-project cards no longer render duplicate prompt/time rows.
+3. Fixed a syntax issue in `[slug].tsx` (`summarizeBlock` closure) that could break compile/runtime.
+
+## Risks / follow-up notes
+
+- Redirecting `/studio` is intentionally conservative and may affect bookmarked links; canonical path should be communicated in release notes.
+- AI generation remains a seam in this step; model-backed generation should be added behind the new interface in a later PR.


### PR DESCRIPTION
### Motivation
- The PRD mandates a single unified studio with a shared Zustand model and an AI generation seam, but the repo contains two divergent studio implementations and inconsistent block schemas. 
- The goal of this change is to lock direction, remove the duplicate entrypoint, and propose a minimal phased plan to converge implementations without introducing large features yet.

### Description
- Added a focused alignment review at `docs/studio-alignment-review.md` that documents the divergence, proposed phased refactor plan, and next steps. 
- Replaced the separate `/studio` page implementation with a redirect component at `apps/web/pages/studio/index.tsx` that forwards users to the landing page to avoid exposing a second divergent studio. 
- Removed duplicated prompt/time rendering in the landing recent projects UI by trimming redundant markup in `apps/web/pages/index.tsx`. 
- Fixed a syntax/closure issue in `apps/web/pages/studio/[slug].tsx` by properly closing the `summarizeBlock` function to ensure correct compilation/runtime behavior. 

### Testing
- Attempted to run the web build with `npm run -w apps/web build`, but the build failed in this environment because `next` is not available (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1776b975c83258e8fcfef1f48d975)